### PR TITLE
Support serialization with DataContractSerializer

### DIFF
--- a/SemVer.Tests/SemVer.Tests.csproj
+++ b/SemVer.Tests/SemVer.Tests.csproj
@@ -40,6 +40,8 @@
       <Name>SemVer</Name>
     </ProjectReference>
     <Reference Include="System" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.XML" />
     <Reference Include="xunit">
       <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
@@ -50,6 +52,7 @@
   <ItemGroup>
     <Compile Include="AdvancedRanges.cs" />
     <Compile Include="LooseMode.cs" />
+    <Compile Include="Serialization.cs" />
     <Compile Include="ParseMajorMinorPatch.cs" />
     <Compile Include="PartialVersion.cs" />
     <Compile Include="PreReleaseComparisons.cs" />

--- a/SemVer.Tests/SemVer.Tests.csproj
+++ b/SemVer.Tests/SemVer.Tests.csproj
@@ -39,6 +39,9 @@
       <Project>{48ba8bb9-c9eb-4f93-bf1b-28e5afec7e55}</Project>
       <Name>SemVer</Name>
     </ProjectReference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />

--- a/SemVer.Tests/Serialization.cs
+++ b/SemVer.Tests/Serialization.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using Xunit.Extensions;
 using Newtonsoft.Json;
 using System.IO;
 using System.Runtime.Serialization;
@@ -32,6 +31,15 @@ namespace SemVer.Tests
             Assert.Equal(3, output.Patch);
             Assert.Equal("alpha2", output.PreRelease);
             Assert.Equal("test", output.Build);
+        }
+
+        [Fact]
+        public void SerializeRange()
+        {
+            var input = new Range("~1.2.3");
+            var output = DeserializeFromXml<Range>(SerializeToXml(input));
+
+            Assert.True(input.Equals(output));
         }
 
         private static string SerializeToXml<T>(T input)

--- a/SemVer.Tests/Serialization.cs
+++ b/SemVer.Tests/Serialization.cs
@@ -1,0 +1,47 @@
+﻿using Xunit;
+using Xunit.Extensions;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace SemVer.Tests
+{
+    public class Serialization
+    {
+        [Fact]
+        public void SerializeVersion()
+        {
+            var input = new Version("1.2.3-alpha2+test");
+            var output = DeserializeFromXml<Version>(SerializeToXml(input));
+
+            Assert.Equal(1, output.Major);
+            Assert.Equal(2, output.Minor);
+            Assert.Equal(3, output.Patch);
+            Assert.Equal("alpha2", output.PreRelease);
+            Assert.Equal("test", output.Build);
+        }
+
+        private static string SerializeToXml<T>(T input)
+        {
+            using (var memoryStream = new MemoryStream())
+            using(StreamReader reader = new StreamReader(memoryStream))
+            {
+                var serializer = new DataContractSerializer(typeof(T));
+                serializer.WriteObject(memoryStream, input);
+                memoryStream.Position = 0;
+                return reader.ReadToEnd();
+            }
+        }
+
+        private static T DeserializeFromXml<T>(string xml)
+        {
+            var deserializer = new DataContractSerializer(typeof(T));
+            var bytes = System.Text.Encoding.UTF8.GetBytes(xml);
+            using (var memoryStream = new MemoryStream(bytes))
+            {
+                memoryStream.Position = 0;
+                return (T)deserializer.ReadObject(memoryStream);
+            }
+        }
+    }
+}
+

--- a/SemVer.Tests/Serialization.cs
+++ b/SemVer.Tests/Serialization.cs
@@ -1,5 +1,6 @@
 ﻿using Xunit;
 using Xunit.Extensions;
+using Newtonsoft.Json;
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -12,6 +13,19 @@ namespace SemVer.Tests
         {
             var input = new Version("1.2.3-alpha2+test");
             var output = DeserializeFromXml<Version>(SerializeToXml(input));
+
+            Assert.Equal(1, output.Major);
+            Assert.Equal(2, output.Minor);
+            Assert.Equal(3, output.Patch);
+            Assert.Equal("alpha2", output.PreRelease);
+            Assert.Equal("test", output.Build);
+        }
+
+        [Fact]
+        public void SerializeVersionWithNewtonsoft()
+        {
+            var input = new Version("1.2.3-alpha2+test");
+            var output = JsonConvert.DeserializeObject<Version>(JsonConvert.SerializeObject(input));
 
             Assert.Equal(1, output.Major);
             Assert.Equal(2, output.Minor);

--- a/SemVer.Tests/packages.config
+++ b/SemVer.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net40" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />
   <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net40" />

--- a/SemVer/Comparator.cs
+++ b/SemVer/Comparator.cs
@@ -1,13 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 
 namespace SemVer
 {
+    [DataContract]
     internal class Comparator : IEquatable<Comparator>
     {
+        [DataMember]
         public readonly Operator ComparatorType;
 
+        [DataMember]
         public readonly Version Version;
 
         private const string pattern = @"

--- a/SemVer/ComparatorSet.cs
+++ b/SemVer/ComparatorSet.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace SemVer
 {
+    [DataContract]
     internal class ComparatorSet : IEquatable<ComparatorSet>
     {
+        [DataMember]
         private readonly List<Comparator> _comparators;
 
         public ComparatorSet(string spec)

--- a/SemVer/Range.cs
+++ b/SemVer/Range.cs
@@ -1,16 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace SemVer
 {
     /// <summary>
     /// Specifies valid versions.
     /// </summary>
+    [DataContract]
     public class Range : IEquatable<Range>
     {
+        [DataMember]
         private readonly ComparatorSet[] _comparatorSets;
 
+        [DataMember]
         private readonly string _rangeSpec;
 
         /// <summary>

--- a/SemVer/Version.cs
+++ b/SemVer/Version.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 
 namespace SemVer
@@ -8,13 +9,20 @@ namespace SemVer
     /// <summary>
     /// A semantic version.
     /// </summary>
+    [DataContract]
     public class Version : IComparable<Version>, IEquatable<Version>
     {
+        [DataMember]
         private readonly string _inputString;
+        [DataMember]
         private readonly int _major;
+        [DataMember]
         private readonly int _minor;
+        [DataMember]
         private readonly int _patch;
+        [DataMember]
         private readonly string _preRelease;
+        [DataMember]
         private readonly string _build;
 
         /// <summary>

--- a/SemVer/Version.cs
+++ b/SemVer/Version.cs
@@ -76,6 +76,9 @@ namespace SemVer
             $",
             RegexOptions.IgnorePatternWhitespace);
 
+        // Private constructor only for use with serialization
+        private Version() : this("0.0.0") { }
+
         /// <summary>
         /// Construct a new semantic version from a version string.
         /// </summary>


### PR DESCRIPTION
Addresses #9 

cc @xaviergonz

I also wanted to support Newtonsoft.JSON and it can use the DataMember attributes to serialize a Version but needs a parameterless constructor. I looked into also supporting Newtonsoft.JSON for serializing ranges but it uses the public constructor that takes a string and passes in null rather than using the private parameterless constructor if there is one. This can be worked around by adding an attribute on the constructor but I don't want to add a dependency on Newtonsoft.JSON just to support serialization for the few people who might use it.

It does seem like implementing custom serialization by implementing ISerializable would have been nicer as then I could just serialize to and from the string representation, but this isn't supported in portable class libraries, so I've had to stick with using the DataContract approach which ties the serialized format to private implementation details, which isn't ideal.

Any suggestions for a better approach? Otherwise I'm probably ok with going with this approach if it'll be useful.
