### PR TITLE
Add Range.Intersect method

### DIFF
--- a/test/SemVer.Tests/RangeOperations.cs
+++ b/test/SemVer.Tests/RangeOperations.cs
@@ -1,0 +1,25 @@
+﻿using Xunit;
+
+namespace SemVer.Tests
+{
+    public class RangeOperations
+    {
+        [Theory]
+        [InlineData("~1.2.3", ">=1.2.0 < 1.2.6", ">=1.2.3 < 1.2.6")]
+        [InlineData("~1.2.3", "~1.3.2", "<0.0.0")]
+        [InlineData("~1.2.3", "=1.2.7", "=1.2.7")]
+        [InlineData("~1.2.3", "=1.3.2", "<0.0.0")]
+        [InlineData("=1.2.3", "=1.2.3", "=1.2.3")]
+        [InlineData("=1.2.3", "=1.2.4", "<0.0.0")]
+        [InlineData("~1.2.3 || ~1.3.2", ">=1.2.9 < 1.3.8", ">=1.2.9 < 1.3.0 || >=1.3.2 < 1.3.8")]
+        public void Intersect(string a, string b, string intersect)
+        {
+            var rangeA = new Range(a);
+            var rangeB = new Range(b);
+            var expected = new Range(intersect);
+
+            var rangeIntersect = rangeA.Intersect(rangeB);
+            Assert.Equal(expected, rangeIntersect);
+        }
+    }
+}


### PR DESCRIPTION
Partly addresses #25. Only adding Intersect for now. Union is already quite straightforward by just using `||` to combine ranges, and difference is a bit more complicated and I'm not sure there's a need for it.