### PR TITLE
Add build number comparison options

### DIFF
--- a/src/SemVer/Options.cs
+++ b/src/SemVer/Options.cs
@@ -1,0 +1,8 @@
+﻿namespace SemVer
+{
+    public static class Options
+    {
+        public static bool CompareNumericBuildNumber { get; set; }
+        public static bool CompareAlphaNumericBuildNumber { get; set; }
+    }
+}

--- a/src/SemVer/PartialVersion.cs
+++ b/src/SemVer/PartialVersion.cs
@@ -16,6 +16,8 @@ namespace SemVer
 
         public string PreRelease { get; set; }
 
+        public string Build { get; set; }
+
         private static Regex regex = new Regex(@"^
                 [v=\s]*
                 (\d+|[Xx\*])                      # major version
@@ -86,6 +88,11 @@ namespace SemVer
             {
                 PreRelease = match.Groups[7].Value;
             }
+
+            if (match.Groups[9].Success)
+            {
+                Build = match.Groups[9].Value;
+            }
         }
 
         public Version ToZeroVersion()
@@ -94,7 +101,8 @@ namespace SemVer
                     Major ?? 0,
                     Minor ?? 0,
                     Patch ?? 0,
-                    PreRelease);
+                    PreRelease,
+                    Build);
         }
 
         public bool IsFull()

--- a/src/SemVer/Version.cs
+++ b/src/SemVer/Version.cs
@@ -224,6 +224,21 @@ namespace SemVer
 
             if (Options.CompareNumericBuildNumber)
             {
+                if (Build == null && other.Build == null)
+                {
+                    return 0;
+                }
+
+                if (Build == null)
+                {
+                    return -1;
+                }
+
+                if (other.Build == null)
+                {
+                    return 1;
+                }
+
                 int thisBuild;
                 if (int.TryParse(Build, out thisBuild))
                 {

--- a/src/SemVer/Version.cs
+++ b/src/SemVer/Version.cs
@@ -216,7 +216,30 @@ namespace SemVer
                 }
             }
 
-            return PreReleaseVersion.Compare(this.PreRelease, other.PreRelease);
+            int comparisonResult = PreReleaseVersion.Compare(this.PreRelease, other.PreRelease);
+            if (comparisonResult != 0)
+            {
+                return comparisonResult;
+            }
+
+            if (Options.CompareNumericBuildNumber)
+            {
+                int thisBuild;
+                if (int.TryParse(Build, out thisBuild))
+                {
+                    int otherBuild;
+                    if (int.TryParse(other.Build, out otherBuild))
+                    {
+                        return thisBuild.CompareTo(otherBuild);
+                    }
+                }
+            }
+            else if (Options.CompareAlphaNumericBuildNumber)
+            {
+                return string.Compare(Build, other.Build, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return comparisonResult;
         }
 
         private IEnumerable<int> PartComparisons(Version other)

--- a/test/SemVer.Tests/VersionComparison.cs
+++ b/test/SemVer.Tests/VersionComparison.cs
@@ -258,12 +258,22 @@ namespace SemVer.Tests
 
         [Theory]
         [InlineData("1.2.3+1", "1.2.3+5")]
+        [InlineData("1.2.3", "1.2.3+5")]
         public void NumericBuildNumberLessThan(string a, string b)
         {
             Options.CompareNumericBuildNumber = true;
             var versionA = new Version(a);
             var versionB = new Version(b);
             Assert.True(versionA < versionB);
+        }
+
+        [Theory]
+        [InlineData(">2.0.0 <2.0.0+37", "2.0.0+31")]
+        public void NumericBuildSatisfyingRange(string rangeSpec, string version)
+        {
+            Options.CompareNumericBuildNumber = true;
+            var range = new Range(rangeSpec);
+            Assert.True(range.IsSatisfied(version));
         }
 
         [Theory]

--- a/test/SemVer.Tests/VersionComparison.cs
+++ b/test/SemVer.Tests/VersionComparison.cs
@@ -5,6 +5,12 @@ namespace SemVer.Tests
 {
     public class VersionComparison
     {
+        public VersionComparison()
+        {
+            Options.CompareNumericBuildNumber = false;
+            Options.CompareAlphaNumericBuildNumber = false;
+        }
+
         [Fact]
         public void EqualVersions()
         {
@@ -248,6 +254,48 @@ namespace SemVer.Tests
             Assert.True(a <= b);
             Assert.True(b > a);
             Assert.True(b >= a);
+        }
+
+        [Theory]
+        [InlineData("1.2.3+1", "1.2.3+5")]
+        public void NumericBuildNumberLessThan(string a, string b)
+        {
+            Options.CompareNumericBuildNumber = true;
+            var versionA = new Version(a);
+            var versionB = new Version(b);
+            Assert.True(versionA < versionB);
+        }
+
+        [Theory]
+        [InlineData("1.2.3+5", "1.2.3+5")]
+        [InlineData("1.2.3+7", "1.2.3+5")]
+        public void NumericBuildNumberNotLessThan(string a, string b)
+        {
+            Options.CompareNumericBuildNumber = true;
+            var versionA = new Version(a);
+            var versionB = new Version(b);
+            Assert.False(versionA < versionB);
+        }
+
+        [Theory]
+        [InlineData("1.2.3+a.1", "1.2.3+b.1")]
+        public void AlphaNumericBuildNumberLessThan(string a, string b)
+        {
+            Options.CompareAlphaNumericBuildNumber = true;
+            var versionA = new Version(a);
+            var versionB = new Version(b);
+            Assert.True(versionA < versionB);
+        }
+
+        [Theory]
+        [InlineData("1.2.3+a.1", "1.2.3+A.1")]
+        [InlineData("1.2.3+a.7", "1.2.3+a.5")]
+        public void AlphaNumericBuildNumberNotLessThan(string a, string b)
+        {
+            Options.CompareAlphaNumericBuildNumber = true;
+            var versionA = new Version(a);
+            var versionB = new Version(b);
+            Assert.False(versionA < versionB);
         }
     }
 }


### PR DESCRIPTION
Please note that prerelease takes precedence over build metadata, as per [semver 2.0 precedence rules (section 11)](http://semver.org/#spec-item-11).