### PR TITLE
Strongly name assembly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.enc binary

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 [Rr]eleases/
 x64/
 x86/
-build/
 bld/
 [Bb]in/
 [Oo]bj/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ branches:
 pull_requests:
   do_not_increment_build_number: true
 install:
+  - nuget install secure-file -ExcludeVersion
+  - ps: .\build\decrypt-snk.ps1
   - ps: .\build\install.ps1
 build_script:
 - ps: .\build\build.ps1 $env:APPVEYOR_BUILD_VERSION $env:APPVEYOR_REPO_TAG_NAME
@@ -21,3 +23,6 @@ deploy:
   on:
       branch: master                # release from master branch only
       appveyor_repo_tag: true       # deploy on tag push only
+environment:
+  ENCRYPTION_KEY:
+    secure: hbiBHn0JfRy73jn/e8rUKMI5Z3T78zXCmpD8dRexuc3uJivS5I5WNf6JiZOdEM8G

--- a/build/decrypt-snk.ps1
+++ b/build/decrypt-snk.ps1
@@ -1,0 +1,20 @@
+if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+    Write-Host "Build is for a pull request, not decrypting SNK file"
+} else {
+    Write-Host "Decrypting SNK file"
+    .\secure-file\tools\secure-file -decrypt .\build\semver-key.snk.enc -secret $env:ENCRYPTION_KEY -out .\build\semver-key.snk
+
+    $projectFiles = @('.\src\SemVer\project.json', '.\test\SemVer.Tests\project.json')
+    foreach ($path in $projectFiles) {
+        Write-Host "Setting keyFile property in $path"
+        $projectFile = Get-Content $path -raw | ConvertFrom-Json
+        $projectFile.buildOptions.keyFile = "../../build/semver-key.snk"
+        $projectFile | ConvertTo-Json -Depth 20 | set-content $path
+    }
+
+    Write-Host "Updating AssemblyInfo.cs"
+    $assemblyInfo = '.\src\SemVer\Properties\AssemblyInfo.cs'
+    (Get-Content $assemblyInfo) |
+        Foreach-Object {$_ -replace 'InternalsVisibleTo\("SemVer.Tests"\)', 'InternalsVisibleTo("SemVer.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010019351d4288017757df1b69b4d0da9a775e6eec498ec93d209d6db4d62e9962476c8da01545cc47335cdc39ba803f4db368ce5f2fdd6cd395196f3328f9039dccdeb3c0f9aece7b8751cd3bc2cb2297d4f463a376eff61b7295b96af9b9faf3eef6005dc967a7a97431cc42cff72e60f05797f3e16186f8fbaf26074e96a2b5e1")'}  |
+        Out-File $assemblyInfo
+}

--- a/build/semver-key.snk.enc
+++ b/build/semver-key.snk.enc
@@ -1,0 +1,6 @@
+úÂöÛäìê¯<è
+„‡çÕ â×5âŒ¢åÑP7å®Î;\ü_ÐöhW|eý:°"ÛôR°Cnüj|©[º—-·…W6³åž]ŽÃiÏMd ƒ§Ë) %úFŸÜr›Ë%t1Òšž=Gü…`B	Ûîàb-^ÊÎk[Ø!Ò:YŸ[»TM;Íâ»é×IwÇþÀ]Í\l§¡÷°KÊ¤ÛVý‘ònQ|fßµ˜Óã±E	*øØ÷â¿;Èfè¸É
+ÑÙ'ËˆyY­©Ð§èx)fºÚ?Ø˜üj4åØ…¬ÓæZnÎè¶$^5/ïúBy”xnêk:Â;ÉWÒŒòaˆ1â’nÉàÉâÕ5X s}˜xcå!HÇ`àM˜,§¤)Áª³€å°YI‘K‡—ÛN}™•`Ÿ·…£”.ëcÐ_\mw9Ò{â%åœûÐwªÁ³°o´íÔl$ßá/ª¤)ðÿL3Õø?óµð¦%t½5‚þ¼ÖrmäŠ©%Õ9Ý‚Àè=
+Ûú'Xh9U;·f3ims.lp·ºÞ«Eˆz‹Þ²5–ð'•¹R‡·Ø[J	‚DÜàqÚ#8ætnþÞSk¾C* 9?cŸLŸ¡×m*Žá°9Ý:Ø&ž¾ö¨:bÚ1g‡ð±‡f€ícÝò^
+½@Þõï¹‡‚­ÖÂöBSï¼”§.á¿4£ŒË‰½ªá¦'ëá4ÙÝ€yóó
+T†óÙfôDüOG+ä_”\îOjÄÀ°Ítë9Üˆì›jZ•jN\¡ª–*¬

--- a/src/SemVer/project.json
+++ b/src/SemVer/project.json
@@ -1,14 +1,15 @@
 ﻿{
   "name": "SemanticVersioning",
   "title": "SemanticVersioning",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "authors": [ "Adam Reeve" ],
   "copyright": "Copyright 2016 Adam Reeve",
   "description": "This library implements the Semantic Versioning 2.0.0 specification and the version range specification used by npm.",
 
   "buildOptions": {
     "optimize": true,
-    "outputName": "SemVer"
+    "outputName": "SemVer",
+    "keyFile": null
   },
 
   "packOptions": {

--- a/test/SemVer.Tests/project.json
+++ b/test/SemVer.Tests/project.json
@@ -2,6 +2,10 @@
   "version": "1.0.0",
   "testRunner": "xunit",
 
+  "buildOptions": {
+    "keyFile": null
+  },
+
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "SemVer": { "target": "project" },


### PR DESCRIPTION
The SNK file used for strong naming is stored encrypted in the
repository and decrypted by Appveyor in the build if it is not a pull
request build.

Fixes #30 