### PR TITLE
Add an includePrerelease option for Range.IsSatisfied and related methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Examples:
 Pre-Release Versions
 --------------------
 
-Versions with a pre-release can only satisfy ranges that contain
+Versions with a pre-release can normally only satisfy ranges that contain
 a comparator with a pre-release version, and the comparator
 version's major, minor and patch components must match those of the
 version being tested.
@@ -147,6 +147,20 @@ range.IsSatisfied("1.2.4-beta.5");  // false
 var range2 = new Range(">=1.2.3");
 range2.IsSatisfied("1.2.4-alpha");  // false
 ```
+
+To change this behaviour and allow any pre-release version to satisfy a range,
+you can set the `includePrerelease` argument to true:
+
+```C#
+var range = new Range(">=1.2.3-beta.2");
+range.IsSatisfied("1.2.4-beta.5", includePrerelease=true);  // true
+
+var range2 = new Range(">=1.2.3");
+range2.IsSatisfied("1.2.4-alpha", includePrerelease=true);  // true
+```
+
+The `Range.Satisfying` and `Range.MaxSatisfying` methods similarly support
+an `includePrerelease` argument to allow any pre-release version.
 
 Version Comparisons
 -------------------

--- a/src/SemanticVersioning/Comparator.cs
+++ b/src/SemanticVersioning/Comparator.cs
@@ -58,7 +58,7 @@ namespace SemanticVersioning
                         }
                         break;
                     case Operator.GreaterThan:
-                        ComparatorType = Operator.GreaterThanOrEqual;
+                        ComparatorType = Operator.GreaterThanOrEqualIncludingPrereleases;
                         if (!partialVersion.Major.HasValue)
                         {
                             // >* is unsatisfiable, so use <0.0.0

--- a/src/SemanticVersioning/Comparator.cs
+++ b/src/SemanticVersioning/Comparator.cs
@@ -76,9 +76,17 @@ namespace SemanticVersioning
                             Version = new Version(partialVersion.Major.Value, partialVersion.Minor.Value + 1, 0);
                         }
                         break;
+                    case Operator.LessThan:
+                        // <1.2.x means <1.2.0 but not allowing 1.2.0 prereleases if includePrereleases is used
+                        ComparatorType = Operator.LessThanExcludingPrereleases;
+                        Version = partialVersion.ToZeroVersion();
+                        break;
+                    case Operator.GreaterThanOrEqual:
+                        // >=1.2.x means >=1.2.0 and includes 1.2.0 prereleases if includePrereleases is used
+                        ComparatorType = Operator.GreaterThanOrEqualIncludingPrereleases;
+                        Version = partialVersion.ToZeroVersion();
+                        break;
                     default:
-                        // <1.2.x means <1.2.0
-                        // >=1.2.x means >=1.2.0
                         Version = partialVersion.ToZeroVersion();
                         break;
                 }
@@ -137,16 +145,20 @@ namespace SemanticVersioning
         {
             switch(ComparatorType)
             {
-                case(Operator.Equal):
+                case Operator.Equal:
                     return version == Version;
-                case(Operator.LessThan):
+                case Operator.LessThan:
                     return version < Version;
-                case(Operator.LessThanOrEqual):
+                case Operator.LessThanOrEqual:
                     return version <= Version;
-                case(Operator.GreaterThan):
+                case Operator.GreaterThan:
                     return version > Version;
-                case(Operator.GreaterThanOrEqual):
+                case Operator.GreaterThanOrEqual:
                     return version >= Version;
+                case Operator.GreaterThanOrEqualIncludingPrereleases:
+                    return version >= Version || (version.IsPreRelease && version.BaseVersion() == Version);
+                case Operator.LessThanExcludingPrereleases:
+                    return version < Version && !(version.IsPreRelease && version.BaseVersion() == Version);
                 default:
                     throw new InvalidOperationException("Comparator type not recognised.");
             }
@@ -156,12 +168,15 @@ namespace SemanticVersioning
         {
             Func<Comparator, bool> operatorIsGreaterThan = c =>
                 c.ComparatorType == Operator.GreaterThan ||
-                c.ComparatorType == Operator.GreaterThanOrEqual;
+                c.ComparatorType == Operator.GreaterThanOrEqual ||
+                c.ComparatorType == Operator.GreaterThanOrEqualIncludingPrereleases;
             Func<Comparator, bool> operatorIsLessThan = c =>
                 c.ComparatorType == Operator.LessThan ||
-                c.ComparatorType == Operator.LessThanOrEqual;
+                c.ComparatorType == Operator.LessThanOrEqual ||
+                c.ComparatorType == Operator.LessThanExcludingPrereleases;
             Func<Comparator, bool> operatorIncludesEqual = c =>
                 c.ComparatorType == Operator.GreaterThanOrEqual ||
+                c.ComparatorType == Operator.GreaterThanOrEqualIncludingPrereleases ||
                 c.ComparatorType == Operator.Equal ||
                 c.ComparatorType == Operator.LessThanOrEqual;
 
@@ -188,6 +203,8 @@ namespace SemanticVersioning
             LessThanOrEqual,
             GreaterThan,
             GreaterThanOrEqual,
+            GreaterThanOrEqualIncludingPrereleases,
+            LessThanExcludingPrereleases,
         }
 
         public override string ToString()
@@ -195,19 +212,21 @@ namespace SemanticVersioning
             string operatorString = null;
             switch(ComparatorType)
             {
-                case(Operator.Equal):
+                case Operator.Equal:
                     operatorString = "=";
                     break;
-                case(Operator.LessThan):
+                case Operator.LessThan:
+                case Operator.LessThanExcludingPrereleases:
                     operatorString = "<";
                     break;
-                case(Operator.LessThanOrEqual):
+                case Operator.LessThanOrEqual:
                     operatorString = "<=";
                     break;
-                case(Operator.GreaterThan):
+                case Operator.GreaterThan:
                     operatorString = ">";
                     break;
-                case(Operator.GreaterThanOrEqual):
+                case Operator.GreaterThanOrEqual:
+                case Operator.GreaterThanOrEqualIncludingPrereleases:
                     operatorString = ">=";
                     break;
                 default:

--- a/src/SemanticVersioning/Comparator.cs
+++ b/src/SemanticVersioning/Comparator.cs
@@ -251,7 +251,7 @@ namespace SemanticVersioning
 
         public override int GetHashCode()
         {
-            return ToString().GetHashCode();
+            return new { ComparatorType, Version }.GetHashCode();
         }
     }
 }

--- a/src/SemanticVersioning/ComparatorSet.cs
+++ b/src/SemanticVersioning/ComparatorSet.cs
@@ -64,10 +64,10 @@ namespace SemanticVersioning
             _comparators = comparators.ToList();
         }
 
-        public bool IsSatisfied(Version version)
+        public bool IsSatisfied(Version version, bool includePrerelease = false)
         {
             bool satisfied = _comparators.All(c => c.IsSatisfied(version));
-            if (version.PreRelease != null)
+            if (version.PreRelease != null && !includePrerelease)
             {
                 // If the version is a pre-release, then one of the
                 // comparators must have the same version and also include

--- a/src/SemanticVersioning/ComparatorSet.cs
+++ b/src/SemanticVersioning/ComparatorSet.cs
@@ -86,10 +86,12 @@ namespace SemanticVersioning
         {
             Func<Comparator, bool> operatorIsGreaterThan = c =>
                 c.ComparatorType == Comparator.Operator.GreaterThan ||
-                c.ComparatorType == Comparator.Operator.GreaterThanOrEqual;
+                c.ComparatorType == Comparator.Operator.GreaterThanOrEqual ||
+                c.ComparatorType == Comparator.Operator.GreaterThanOrEqualIncludingPrereleases;
             Func<Comparator, bool> operatorIsLessThan = c =>
                 c.ComparatorType == Comparator.Operator.LessThan ||
-                c.ComparatorType == Comparator.Operator.LessThanOrEqual;
+                c.ComparatorType == Comparator.Operator.LessThanOrEqual ||
+                c.ComparatorType == Comparator.Operator.LessThanExcludingPrereleases;
             var maxOfMins =
                 _comparators.Concat(other._comparators)
                 .Where(operatorIsGreaterThan)

--- a/src/SemanticVersioning/Desugarer.cs
+++ b/src/SemanticVersioning/Desugarer.cs
@@ -41,7 +41,7 @@ namespace SemanticVersioning
 
             return Tuple.Create(
                     match.Length,
-                    minMaxComparators(minVersion, maxVersion));
+                    MinMaxComparators(minVersion, maxVersion));
         }
 
         // Allows changes that do not modify the left-most non-zero digit
@@ -95,7 +95,7 @@ namespace SemanticVersioning
 
             return Tuple.Create(
                     match.Length,
-                    minMaxComparators(minVersion, maxVersion));
+                    MinMaxComparators(minVersion, maxVersion, minOperator: Comparator.Operator.GreaterThanOrEqualIncludingPrereleases));
         }
 
         public static Tuple<int, Comparator[]> HyphenRange(string spec)
@@ -128,7 +128,7 @@ namespace SemanticVersioning
             var minVersion = minPartialVersion.ToZeroVersion();
 
             Comparator.Operator maxOperator = maxPartialVersion.IsFull()
-                ? Comparator.Operator.LessThanOrEqual : Comparator.Operator.LessThan;
+                ? Comparator.Operator.LessThanOrEqual : Comparator.Operator.LessThanExcludingPrereleases;
 
             Version maxVersion = null;
 
@@ -153,7 +153,10 @@ namespace SemanticVersioning
             }
             return Tuple.Create(
                     match.Length,
-                    minMaxComparators(minVersion, maxVersion, maxOperator));
+                    MinMaxComparators(
+                        minVersion, maxVersion,
+                        minOperator: Comparator.Operator.GreaterThanOrEqualIncludingPrereleases,
+                        maxOperator: maxOperator));
         }
 
         public static Tuple<int, Comparator[]> StarRange(string spec)
@@ -206,23 +209,21 @@ namespace SemanticVersioning
 
             return Tuple.Create(
                     match.Length,
-                    minMaxComparators(minVersion, maxVersion));
+                    MinMaxComparators(minVersion, maxVersion));
         }
 
-        private static Comparator[] minMaxComparators(Version minVersion, Version maxVersion,
-                Comparator.Operator maxOperator=Comparator.Operator.LessThan)
+        private static Comparator[] MinMaxComparators(Version minVersion, Version maxVersion,
+                Comparator.Operator minOperator=Comparator.Operator.GreaterThanOrEqual,
+                Comparator.Operator maxOperator=Comparator.Operator.LessThanExcludingPrereleases)
         {
-            var minComparator = new Comparator(
-                    Comparator.Operator.GreaterThanOrEqual,
-                    minVersion);
+            var minComparator = new Comparator(minOperator, minVersion);
             if (maxVersion == null)
             {
                 return new [] { minComparator };
             }
             else
             {
-                var maxComparator = new Comparator(
-                        maxOperator, maxVersion);
+                var maxComparator = new Comparator(maxOperator, maxVersion);
                 return new [] { minComparator, maxComparator };
             }
         }

--- a/src/SemanticVersioning/Range.cs
+++ b/src/SemanticVersioning/Range.cs
@@ -36,10 +36,11 @@ namespace SemanticVersioning
         /// Determine whether the given version satisfies this range.
         /// </summary>
         /// <param name="version">The version to check.</param>
+        /// <param name="includePrerelease">When true, allow prerelease versions to satisfy the range.</param>
         /// <returns>true if the range is satisfied by the version.</returns>
-        public bool IsSatisfied(Version version)
+        public bool IsSatisfied(Version version, bool includePrerelease = false)
         {
-            return _comparatorSets.Any(s => s.IsSatisfied(version));
+            return _comparatorSets.Any(s => s.IsSatisfied(version, includePrerelease: includePrerelease));
         }
 
         /// <summary>
@@ -48,13 +49,14 @@ namespace SemanticVersioning
         /// </summary>
         /// <param name="versionString">The version to check.</param>
         /// <param name="loose">When true, be more forgiving of some invalid version specifications.</param>
+        /// <param name="includePrerelease">When true, allow prerelease versions to satisfy the range.</param>
         /// <returns>true if the range is satisfied by the version.</returns>
-        public bool IsSatisfied(string versionString, bool loose = false)
+        public bool IsSatisfied(string versionString, bool loose = false, bool includePrerelease = false)
         {
             try
             {
                 var version = new Version(versionString, loose);
-                return IsSatisfied(version);
+                return IsSatisfied(version, includePrerelease: includePrerelease);
             }
             catch (ArgumentException)
             {
@@ -66,10 +68,11 @@ namespace SemanticVersioning
         /// Return the set of versions that satisfy this range.
         /// </summary>
         /// <param name="versions">The versions to check.</param>
+        /// <param name="includePrerelease">When true, allow prerelease versions to satisfy the range.</param>
         /// <returns>An IEnumerable of satisfying versions.</returns>
-        public IEnumerable<Version> Satisfying(IEnumerable<Version> versions)
+        public IEnumerable<Version> Satisfying(IEnumerable<Version> versions, bool includePrerelease = false)
         {
-            return versions.Where(IsSatisfied);
+            return versions.Where(v => IsSatisfied(v, includePrerelease: includePrerelease));
         }
 
         /// <summary>
@@ -78,20 +81,22 @@ namespace SemanticVersioning
         /// </summary>
         /// <param name="versions">The version strings to check.</param>
         /// <param name="loose">When true, be more forgiving of some invalid version specifications.</param>
+        /// <param name="includePrerelease">When true, allow prerelease versions to satisfy the range.</param>
         /// <returns>An IEnumerable of satisfying version strings.</returns>
-        public IEnumerable<string> Satisfying(IEnumerable<string> versions, bool loose = false)
+        public IEnumerable<string> Satisfying(IEnumerable<string> versions, bool loose = false, bool includePrerelease = false)
         {
-            return versions.Where(v => IsSatisfied(v, loose));
+            return versions.Where(v => IsSatisfied(v, loose, includePrerelease));
         }
 
         /// <summary>
         /// Return the maximum version that satisfies this range.
         /// </summary>
         /// <param name="versions">The versions to select from.</param>
+        /// <param name="includePrerelease">When true, allow prerelease versions to satisfy the range.</param>
         /// <returns>The maximum satisfying version, or null if no versions satisfied this range.</returns>
-        public Version MaxSatisfying(IEnumerable<Version> versions)
+        public Version MaxSatisfying(IEnumerable<Version> versions, bool includePrerelease = false)
         {
-            return Satisfying(versions).Max();
+            return Satisfying(versions, includePrerelease: includePrerelease).Max();
         }
 
         /// <summary>
@@ -99,11 +104,12 @@ namespace SemanticVersioning
         /// </summary>
         /// <param name="versionStrings">The version strings to select from.</param>
         /// <param name="loose">When true, be more forgiving of some invalid version specifications.</param>
+        /// <param name="includePrerelease">When true, allow prerelease versions to satisfy the range.</param>
         /// <returns>The maximum satisfying version string, or null if no versions satisfied this range.</returns>
-        public string MaxSatisfying(IEnumerable<string> versionStrings, bool loose = false)
+        public string MaxSatisfying(IEnumerable<string> versionStrings, bool loose = false, bool includePrerelease = false)
         {
             var versions = ValidVersions(versionStrings, loose);
-            var maxVersion = MaxSatisfying(versions);
+            var maxVersion = MaxSatisfying(versions, includePrerelease: includePrerelease);
             return maxVersion == null ? null : maxVersion.ToString();
         }
 
@@ -179,11 +185,12 @@ namespace SemanticVersioning
         /// <param name="rangeSpec">The range specification.</param>
         /// <param name="versionString">The version to check.</param>
         /// <param name="loose">When true, be more forgiving of some invalid version specifications.</param>
+        /// <param name="includePrerelease">When true, allow prerelease versions to satisfy the range.</param>
         /// <returns>true if the range is satisfied by the version.</returns>
-        public static bool IsSatisfied(string rangeSpec, string versionString, bool loose = false)
+        public static bool IsSatisfied(string rangeSpec, string versionString, bool loose = false, bool includePrerelease = false)
         {
             var range = new Range(rangeSpec);
-            return range.IsSatisfied(versionString);
+            return range.IsSatisfied(versionString, loose: loose, includePrerelease: includePrerelease);
         }
 
         /// <summary>
@@ -194,10 +201,10 @@ namespace SemanticVersioning
         /// <param name="versions">The version strings to check.</param>
         /// <param name="loose">When true, be more forgiving of some invalid version specifications.</param>
         /// <returns>An IEnumerable of satisfying version strings.</returns>
-        public static IEnumerable<string> Satisfying(string rangeSpec, IEnumerable<string> versions, bool loose = false)
+        public static IEnumerable<string> Satisfying(string rangeSpec, IEnumerable<string> versions, bool loose = false, bool includePrerelease = false)
         {
             var range = new Range(rangeSpec);
-            return range.Satisfying(versions);
+            return range.Satisfying(versions, loose: loose, includePrerelease: includePrerelease);
         }
 
         /// <summary>
@@ -206,11 +213,12 @@ namespace SemanticVersioning
         /// <param name="rangeSpec">The range specification.</param>
         /// <param name="versionStrings">The version strings to select from.</param>
         /// <param name="loose">When true, be more forgiving of some invalid version specifications.</param>
+        /// <param name="includePrerelease">When true, allow prerelease versions to satisfy the range.</param>
         /// <returns>The maximum satisfying version string, or null if no versions satisfied this range.</returns>
-        public static string MaxSatisfying(string rangeSpec, IEnumerable<string> versionStrings, bool loose = false)
+        public static string MaxSatisfying(string rangeSpec, IEnumerable<string> versionStrings, bool loose = false, bool includePrerelease = false)
         {
             var range = new Range(rangeSpec);
-            return range.MaxSatisfying(versionStrings);
+            return range.MaxSatisfying(versionStrings, includePrerelease: includePrerelease);
         }
 
         /// <summary>

--- a/src/SemanticVersioning/Version.cs
+++ b/src/SemanticVersioning/Version.cs
@@ -42,6 +42,11 @@ namespace SemanticVersioning
         /// </summary>
         public string Build { get { return _build; } }
 
+        /// <summary>
+        /// Whether this version is a pre-release
+        /// </summary>
+        public bool IsPreRelease { get { return !string.IsNullOrEmpty(_preRelease); } }
+
         private static Regex strictRegex = new Regex(@"^
             \s*v?
             ([0-9]|[1-9][0-9]+)       # major version

--- a/test/SemanticVersioning.Tests/AdvancedRanges.cs
+++ b/test/SemanticVersioning.Tests/AdvancedRanges.cs
@@ -7,17 +7,18 @@ namespace SemanticVersioning.Tests
     public class AdvancedRanges
     {
         [Theory]
-        [InlineData("~1.2.3", ">=1.2.3", "<1.3.0")]
-        [InlineData("~1.2", ">=1.2.0", "<1.3.0")]
-        [InlineData("~1", ">=1.0.0", "<2.0.0")]
-        [InlineData("~0.2.3", ">=0.2.3", "<0.3.0")]
-        [InlineData("~0.2", ">=0.2.0", "<0.3.0")]
-        [InlineData("~0", ">=0.0.0", "<1.0.0")]
+        [InlineData("~1.2.3", ">=1.2.3", "1.3.0")]
+        [InlineData("~1.2", ">=1.2.0", "1.3.0")]
+        [InlineData("~1", ">=1.0.0", "2.0.0")]
+        [InlineData("~0.2.3", ">=0.2.3", "0.3.0")]
+        [InlineData("~0.2", ">=0.2.0", "0.3.0")]
+        [InlineData("~0", ">=0.0.0", "1.0.0")]
         public void TestTildeRanges(string range,
-                string comparatorStringA, string comparatorStringB)
+                string comparatorStringA, string comparatorVersionB)
         {
             var comparatorA = new Comparator(comparatorStringA);
-            var comparatorB = new Comparator(comparatorStringB);
+            var comparatorB = new Comparator(
+                Comparator.Operator.LessThanExcludingPrereleases, Version.Parse(comparatorVersionB));
             var comparators = Desugarer.TildeRange(range).Item2;
             Assert.Equal(comparators.Count(), 2);
             Assert.Contains(comparatorA, comparators);
@@ -25,20 +26,21 @@ namespace SemanticVersioning.Tests
         }
 
         [Theory]
-        [InlineData("^1.2.3", ">=1.2.3", "<2.0.0")]
-        [InlineData("^0.2.3", ">=0.2.3", "<0.3.0")]
-        [InlineData("^0.0.3", ">=0.0.3", "<0.0.4")]
-        [InlineData("^1.2.x", ">=1.2.0", "<2.0.0")]
-        [InlineData("^0.0.x", ">=0.0.0", "<0.1.0")]
-        [InlineData("^0.0", ">=0.0.0", "<0.1.0")]
-        [InlineData("^1.x", ">=1.0.0", "<2.0.0")]
-        [InlineData("^0.x", ">=0.0.0", "<1.0.0")]
-        [InlineData("^0.0.0", ">=0.0.0", "<0.0.1")]
-        public void TestCaretRanges(string range,
-                string comparatorStringA, string comparatorStringB)
+        [InlineData("^1.2.3", "1.2.3", "2.0.0")]
+        [InlineData("^0.2.3", "0.2.3", "0.3.0")]
+        [InlineData("^0.0.3", "0.0.3", "0.0.4")]
+        [InlineData("^1.2.x", "1.2.0", "2.0.0")]
+        [InlineData("^0.0.x", "0.0.0", "0.1.0")]
+        [InlineData("^0.0", "0.0.0", "0.1.0")]
+        [InlineData("^1.x", "1.0.0", "2.0.0")]
+        [InlineData("^0.x", "0.0.0", "1.0.0")]
+        [InlineData("^0.0.0", "0.0.0", "0.0.1")]
+        public void TestCaretRanges(string range, string comparatorVersionA, string comparatorVersionB)
         {
-            var comparatorA = new Comparator(comparatorStringA);
-            var comparatorB = new Comparator(comparatorStringB);
+            var comparatorA = new Comparator(
+                Comparator.Operator.GreaterThanOrEqualIncludingPrereleases, Version.Parse(comparatorVersionA));
+            var comparatorB = new Comparator(
+                Comparator.Operator.LessThanExcludingPrereleases, Version.Parse(comparatorVersionB));
             var comparators = Desugarer.CaretRange(range).Item2;
             Assert.Equal(comparators.Count(), 2);
             Assert.Contains(comparatorA, comparators);
@@ -61,6 +63,10 @@ namespace SemanticVersioning.Tests
             foreach (var comparatorString in comparatorStrings)
             {
                 var comparator = new Comparator(comparatorString);
+                if (comparator.ComparatorType == Comparator.Operator.LessThan)
+                {
+                    comparator = new Comparator(Comparator.Operator.LessThanExcludingPrereleases, comparator.Version);
+                }
                 Assert.Contains(comparator, comparators);
             }
         }
@@ -79,6 +85,14 @@ namespace SemanticVersioning.Tests
             foreach (var comparatorString in comparatorStrings)
             {
                 var comparator = new Comparator(comparatorString);
+                if (comparator.ComparatorType == Comparator.Operator.LessThan)
+                {
+                    comparator = new Comparator(Comparator.Operator.LessThanExcludingPrereleases, comparator.Version);
+                }
+                else if (comparator.ComparatorType == Comparator.Operator.GreaterThanOrEqual)
+                {
+                    comparator = new Comparator(Comparator.Operator.GreaterThanOrEqualIncludingPrereleases, comparator.Version);
+                }
                 Assert.Contains(comparator, comparators);
             }
         }

--- a/test/SemanticVersioning.Tests/PreReleaseRanges.cs
+++ b/test/SemanticVersioning.Tests/PreReleaseRanges.cs
@@ -31,6 +31,29 @@ namespace SemanticVersioning.Tests
         }
 
         [Theory]
+        [InlineData(">1.2.3-alpha.3", "1.2.3")]
+        [InlineData(">1.2.3-alpha.3", "1.2.3-alpha.4")]
+        [InlineData(">1.2.3-alpha.3", "3.4.5-alpha.1")]
+        public void MatchingPreReleaseWithIncludePrereleases(string rangeString, string versionString)
+        {
+            var range = new Range(rangeString);
+            var version = new Version(versionString);
+            Assert.True(range.IsSatisfied(version, includePrerelease: true));
+        }
+
+        [Theory]
+        [InlineData("1.2.3", "1.2.3-alpha.3")]
+        [InlineData("1.2.3-alpha.3", "1.2.3-alpha.7")]
+        [InlineData("1.2.3-alpha.3", "1.2.3")]
+        [InlineData(">1.2.3-alpha.3", "1.2.3-alpha.2")]
+        public void ExcludedPreReleaseWithIncludePrereleases(string rangeString, string versionString)
+        {
+            var range = new Range(rangeString);
+            var version = new Version(versionString);
+            Assert.False(range.IsSatisfied(version, includePrerelease: true));
+        }
+
+        [Theory]
         [InlineData("~1.2.3-alpha.3", "1.2.3-alpha.7")]
         [InlineData("~1.2.3-alpha.3", "1.2.5")]
         [InlineData("1.2.3-alpha.3 - 1.2.4", "1.2.3-alpha.7")]

--- a/test/SemanticVersioning.Tests/PreReleaseRanges.cs
+++ b/test/SemanticVersioning.Tests/PreReleaseRanges.cs
@@ -34,6 +34,22 @@ namespace SemanticVersioning.Tests
         [InlineData(">1.2.3-alpha.3", "1.2.3")]
         [InlineData(">1.2.3-alpha.3", "1.2.3-alpha.4")]
         [InlineData(">1.2.3-alpha.3", "3.4.5-alpha.1")]
+        [InlineData("<1.3.0", "1.2.3-alpha.4")]
+        [InlineData("<1.3.0-alpha.1", "1.2.3-alpha.4")]
+        [InlineData("<1.3.0-alpha.1", "1.2.3")]
+        [InlineData("<1.3.0-alpha.3", "1.3.0-alpha.2")]
+        [InlineData("<=1.3.0-alpha.3", "1.3.0-alpha.3")]
+        [InlineData("<=1.3.0", "1.3.0-alpha.3")]
+        [InlineData(">=1.3.0", "1.3.1-alpha.1")]
+        [InlineData("<1.3.0", "1.3.0-alpha.1")]
+        [InlineData(">1.3", "1.4.0-alpha.1")]
+        [InlineData(">=1.3", "1.3.0-alpha.1")]
+        [InlineData("1.2 - 1.3", "1.2.0-alpha.1")]
+        [InlineData("1.2 - 1.3", "1.3.0-alpha.1")]
+        [InlineData("1.2.0 - 1.3.0", "1.2.0-alpha.1")]
+        [InlineData("1.2.0 - 1.3.0", "1.3.0-alpha.1")]
+        [InlineData("^0.2.3", "0.2.3-alpha")]
+        [InlineData("^0.2.3", "0.2.4-alpha")]
         public void MatchingPreReleaseWithIncludePrereleases(string rangeString, string versionString)
         {
             var range = new Range(rangeString);
@@ -46,6 +62,12 @@ namespace SemanticVersioning.Tests
         [InlineData("1.2.3-alpha.3", "1.2.3-alpha.7")]
         [InlineData("1.2.3-alpha.3", "1.2.3")]
         [InlineData(">1.2.3-alpha.3", "1.2.3-alpha.2")]
+        [InlineData("<1.3.0-alpha.3", "1.3.0-alpha.4")]
+        [InlineData(">=1.3.0", "1.3.0-alpha.4")]
+        [InlineData("<1.3", "1.3.0-alpha.1")]
+        [InlineData("~1.2.3", "1.3.0-alpha.1")]
+        [InlineData("^0.2.3", "0.2.2-alpha")]
+        [InlineData("^0.2.3", "0.3.0-alpha")]
         public void ExcludedPreReleaseWithIncludePrereleases(string rangeString, string versionString)
         {
             var range = new Range(rangeString);

--- a/test/SemanticVersioning.Tests/RangeEquals.cs
+++ b/test/SemanticVersioning.Tests/RangeEquals.cs
@@ -7,8 +7,9 @@ namespace SemanticVersioning.Tests
     public class RangeEquals
     {
         [Theory]
-        [InlineData("~1.2.3", ">=1.2.3 <1.3.0")]
-        [InlineData("~1.2.3 || =1.3.2", "=1.3.2 || >=1.2.3 <1.3.0")]
+        [InlineData(">=1.2.3 <1.3.0", "<1.3.0 >=1.2.3")]
+        [InlineData("~1.2.3 || =1.3.2", "=1.3.2 || ~1.2.3")]
+        [InlineData("<=1.2", "<1.3.0")]
         public void EqualRanges(string a, string b)
         {
             var aRange = new Range(a);
@@ -33,8 +34,9 @@ namespace SemanticVersioning.Tests
         }
 
         [Theory]
-        [InlineData("~1.2.3", ">=1.2.3 <1.3.0")]
-        [InlineData("~1.2.3 || =1.3.2", "=1.3.2 || >=1.2.3 <1.3.0")]
+        [InlineData(">=1.2.3 <1.3.0", "<1.3.0 >=1.2.3")]
+        [InlineData("~1.2.3 || =1.3.2", "=1.3.2 || ~1.2.3")]
+        [InlineData("<=1.2", "<1.3.0")]
         public void EqualHashes(string a, string b)
         {
             var aRange = new Range(a);

--- a/test/SemanticVersioning.Tests/RangeOperations.cs
+++ b/test/SemanticVersioning.Tests/RangeOperations.cs
@@ -11,7 +11,7 @@ namespace SemanticVersioning.Tests
         [InlineData("~1.2.3", "=1.3.2", "<0.0.0")]
         [InlineData("=1.2.3", "=1.2.3", "=1.2.3")]
         [InlineData("=1.2.3", "=1.2.4", "<0.0.0")]
-        [InlineData("~1.2.3 || ~1.3.2", ">=1.2.9 < 1.3.8", ">=1.2.9 < 1.3.0 || >=1.3.2 < 1.3.8")]
+        [InlineData("~1.2.3 || ~1.3.2", ">=1.2.9 < 1.3.8", "~1.2.9 || >=1.3.2 < 1.3.8")]
         [InlineData("<3.0.0", ">=3.0.0", "<0.0.0")]
         [InlineData("^2", "^3", "<0.0.0")]
         public void Intersect(string a, string b, string intersect)

--- a/test/SemanticVersioning.Tests/StaticRangeMethods.cs
+++ b/test/SemanticVersioning.Tests/StaticRangeMethods.cs
@@ -47,5 +47,52 @@ namespace SemanticVersioning.Tests
             var satisfied = Range.IsSatisfied(range, version);
             Assert.Equal(expectedSatisfied, satisfied);
         }
+
+        [Fact]
+        public void TestMaxSatisfyingWithIncludePreRelease()
+        {
+            var versions = new [] {
+                "1.2.7",
+                "v1.2.8",
+                "v1.2.98",
+                "v1.2.99-alpha.1",
+                "1.2.6",
+                "v1.3.0",
+                "v1.1.0",
+            };
+            var max = Range.MaxSatisfying(">=1.2.7 <1.3.0", versions, includePrerelease: true);
+            Assert.Equal("v1.2.99-alpha.1", max);
+        }
+
+        [Fact]
+        public void TestSatisfyingWithIncludePreRelease()
+        {
+            var versions = new [] {
+                "1.2.7",
+                "v1.2.8-beta.2",
+                "v1.2.98",
+                "v1.2.99-alpha.1",
+                "1.2.6",
+                "v1.3.0",
+                "v1.1.0",
+            };
+            var satisfying = Range.Satisfying(">=1.2.7 <1.3.0", versions, includePrerelease: true).ToArray();
+            Assert.Equal(4, satisfying.Count());
+            Assert.Contains("1.2.7", satisfying);
+            Assert.Contains("v1.2.98", satisfying);
+            Assert.Contains("v1.2.8-beta.2", satisfying);
+            Assert.Contains("v1.2.99-alpha.1", satisfying);
+        }
+
+        [Theory]
+        [InlineData("~1.2.3", "1.2.5-alpha", true)]
+        [InlineData("~1.2.3", "1.3.0-alpha", false)]
+        [InlineData("^0.2.3", "0.2.5-alpha", true)]
+        [InlineData("^0.2.3", "0.3.0-alpha", false)]
+        public void TestIsSatisfiedWithIncludePreRelease(string range, string version, bool expectedSatisfied)
+        {
+            var satisfied = Range.IsSatisfied(range, version, includePrerelease: true);
+            Assert.Equal(expectedSatisfied, satisfied);
+        }
     }
 }


### PR DESCRIPTION
Fixes #49 

This turned out to be slightly more complicated than I initially thought as it changes the meaning of something like `~1.2.0`. Previously that could be treated the same as `>=1.2.0 <1.3.0` but that would allow eg. `1.3.0-alpha.1` to satisfy the range when includePrerelease is true, which is not the desired behaviour. To avoid this I've added new operators, GreaterThanOrEqualIncludingPrereleases and LessThanExcludingPrereleases.

This is a breaking change in terms of binary compatibility due to then new optional arguments, and also changes behaviour as previously equal range specifications might no longer be equal.